### PR TITLE
Add handling for RegExp values

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,3 @@ FROM_DOT_ENV_STRING_ARRAY=a,b,c
 FROM_DOT_ENV_OBJECT_ARRAY=o,b,j,e,c,t
 FROM_DOT_ENV_WITH_DOT=WITH_DOT_ENV
 FROM_DOT_ENV_REGEX='some-regex-from-dot-env.*'
-FROM_DOT_ENV_REGEX_WITH_FLAGS='/some-regex-with-flags-from-dot-env.*/gmi'

--- a/.env
+++ b/.env
@@ -8,3 +8,5 @@ FROM_DOT_ENV_BOOLEAN_ARRAY=false,true,false
 FROM_DOT_ENV_STRING_ARRAY=a,b,c
 FROM_DOT_ENV_OBJECT_ARRAY=o,b,j,e,c,t
 FROM_DOT_ENV_WITH_DOT=WITH_DOT_ENV
+FROM_DOT_ENV_REGEX='some-regex-from-dot-env.*'
+FROM_DOT_ENV_REGEX_WITH_FLAGS='/some-regex-with-flags-from-dot-env.*/gmi'

--- a/config/config.js
+++ b/config/config.js
@@ -11,8 +11,7 @@ module.exports = {
     objectArray: [{}, {}],
     camelCase: 'camelCase',
     'with.dot': 'with.dot',
-    regex: new RegExp('some-regex.*'),
-    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+    regex: new RegExp('some-regex.*', 'gi')
   },
   from: {
     dot_env: {
@@ -27,8 +26,7 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     }
   },
   from_env: {
@@ -47,8 +45,7 @@ module.exports = {
       nested: 'nestedCamelCase'
     },
     'with.dot': 'with.dot',
-    regex: new RegExp('some-regex.*'),
-    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+    regex: new RegExp('some-regex.*', 'gi')
   },
   from_test_json: {
     number: 0.0,
@@ -63,7 +60,6 @@ module.exports = {
     camelCase: 'camelCase',
     null: null,
     'with.dot': 'with.dot',
-    regex: new RegExp('some-regex.*'),
-    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+    regex: new RegExp('some-regex.*', 'gi')
   }
 };

--- a/config/config.js
+++ b/config/config.js
@@ -10,7 +10,9 @@ module.exports = {
     //should be treated as string array
     objectArray: [{}, {}],
     camelCase: 'camelCase',
-    'with.dot': 'with.dot'
+    'with.dot': 'with.dot',
+    regex: new RegExp('some-regex.*'),
+    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
   },
   from: {
     dot_env: {
@@ -24,7 +26,9 @@ module.exports = {
       //should be treated as string array
       objectArray: [{}, {}],
       camelCase: 'camelCase',
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     }
   },
   from_env: {
@@ -42,7 +46,9 @@ module.exports = {
     nestedCamelCase: {
       nested: 'nestedCamelCase'
     },
-    'with.dot': 'with.dot'
+    'with.dot': 'with.dot',
+    regex: new RegExp('some-regex.*'),
+    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
   },
   from_test_json: {
     number: 0.0,
@@ -56,6 +62,8 @@ module.exports = {
     objectArray: [{}, {}],
     camelCase: 'camelCase',
     null: null,
-    'with.dot': 'with.dot'
+    'with.dot': 'with.dot',
+    regex: new RegExp('some-regex.*'),
+    regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
   }
 };

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -10,6 +10,8 @@
     "objectArray": ["1"],
     "camelCase": "test",
     "null": "null",
-    "with.dot": "from_test_json"
+    "with.dot": "from_test_json",
+    "regex": "some-regex-from-test-json.*",
+    "regexWithFlags": "/some-regex-with-flags-from-test-json.*/i"
   }
 }

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -11,7 +11,6 @@
     "camelCase": "test",
     "null": "null",
     "with.dot": "from_test_json",
-    "regex": "some-regex-from-test-json.*",
-    "regexWithFlags": "/some-regex-with-flags-from-test-json.*/i"
+    "regex": "some-regex-from-test-json.*"
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,7 @@ const getEnvValue = (path, key) => process.env[`${path}${key}`.toUpperCase()];
 
 const isObject = val => val && Object === val.constructor;
 
-const castValue = (value, type) => {
+const castValue = (value, type, configValue) => {
   const defaultArrayRegExp = new RegExp('.*?\\[\\]');
   const defaultArray = type => defaultArrayRegExp.test(type);
   switch (type) {
@@ -24,7 +24,7 @@ const castValue = (value, type) => {
     case 'boolean':
       return value === 'true';
     case 'RegExp':
-      return regex(value);
+      return RegExp(value, configValue.flags);
     case 'string':
     default:
       if (defaultArray(type)) {
@@ -50,13 +50,6 @@ function snakeCase(str) {
   return str.replace(/(\w)([A-Z]+)/g, (_, w, W) => `${w}_${W.toLowerCase()}`).replace(/\./g, '_');
 }
 
-function regex(str) {
-  const hasFlags = new RegExp('/.*/[dgimsuvy]*$').test(str);
-  const flags = hasFlags ? str.substring(str.lastIndexOf('/')).substring(1) : undefined;
-  const patternWithoutFlags = hasFlags ? str.substring(1, str.lastIndexOf('/')) : str;
-  return new RegExp(patternWithoutFlags, flags);
-}
-
 const replace = (config, path, key) => {
   const envValue = getEnvValue(path, key) || getEnvValue(snakeCase(path), snakeCase(key));
 
@@ -64,7 +57,7 @@ const replace = (config, path, key) => {
     return;
   }
 
-  config[key] = castValue(envValue, getType(config[key]));
+  config[key] = castValue(envValue, getType(config[key]), config[key]);
 };
 
 const replaceConfigFromEnv = (config, path = '') => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,6 +23,8 @@ const castValue = (value, type) => {
       return Number(value);
     case 'boolean':
       return value === 'true';
+    case 'RegExp':
+      return regex(value);
     case 'string':
     default:
       if (defaultArray(type)) {
@@ -38,11 +40,21 @@ function getType(config) {
     // returns number[], boolean[], string[]
     return `${typeof firstElement}[]`;
   }
+  if (config instanceof RegExp) {
+    return 'RegExp';
+  }
   return typeof config;
 }
 
 function snakeCase(str) {
   return str.replace(/(\w)([A-Z]+)/g, (_, w, W) => `${w}_${W.toLowerCase()}`).replace(/\./g, '_');
+}
+
+function regex(str) {
+  const hasFlags = new RegExp('/.*/[dgimsuvy]*$').test(str);
+  const flags = hasFlags ? str.substring(str.lastIndexOf('/')).substring(1) : undefined;
+  const patternWithoutFlags = hasFlags ? str.substring(1, str.lastIndexOf('/')) : str;
+  return new RegExp(patternWithoutFlags, flags);
 }
 
 const replace = (config, path, key) => {

--- a/test/scenarios/es6default.js
+++ b/test/scenarios/es6default.js
@@ -14,7 +14,9 @@ module.exports = {
     FROM_ENV_STRING_ARRAY: 'c,d,e',
     FROM_ENV_OBJECT_ARRAY: 'c,d,e',
     FROM_ENV_CAMEL_CASE: 'snake_case',
-    FROM_ENV_WITH_DOT: 'WITH_DOT'
+    FROM_ENV_WITH_DOT: 'WITH_DOT',
+    FROM_ENV_REGEX: 'some-regex-from-env.*',
+    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
   },
   expected: {
     nested: {
@@ -27,7 +29,9 @@ module.exports = {
       stringArray: ['a', 'b', 'c'],
       objectArray: [{}, {}],
       camelCase: 'camelCase',
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     },
     from: {
       dot_env: {
@@ -40,7 +44,9 @@ module.exports = {
         stringArray: ['a', 'b', 'c'],
         objectArray: [{}, {}],
         camelCase: 'camelCase',
-        'with.dot': 'with.dot'
+        'with.dot': 'with.dot',
+        regex: new RegExp('some-regex.*'),
+        regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
       }
     },
     from_env: {
@@ -57,7 +63,9 @@ module.exports = {
       nestedCamelCase: {
         nested: 'nestedCamelCase'
       },
-      'with.dot': 'WITH_DOT'
+      'with.dot': 'WITH_DOT',
+      regex: new RegExp('some-regex-from-env.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
     },
     from_test_json: {
       number: 1000.0,
@@ -70,7 +78,9 @@ module.exports = {
       objectArray: ['1'],
       camelCase: 'test',
       null: 'null',
-      'with.dot': 'from_test_json'
+      'with.dot': 'from_test_json',
+      regex: 'some-regex-from-test-json.*',
+      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
     }
   }
 };

--- a/test/scenarios/es6default.js
+++ b/test/scenarios/es6default.js
@@ -15,8 +15,7 @@ module.exports = {
     FROM_ENV_OBJECT_ARRAY: 'c,d,e',
     FROM_ENV_CAMEL_CASE: 'snake_case',
     FROM_ENV_WITH_DOT: 'WITH_DOT',
-    FROM_ENV_REGEX: 'some-regex-from-env.*',
-    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
+    FROM_ENV_REGEX: 'some-regex-from-env.*'
   },
   expected: {
     nested: {
@@ -30,8 +29,7 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     },
     from: {
       dot_env: {
@@ -45,8 +43,7 @@ module.exports = {
         objectArray: [{}, {}],
         camelCase: 'camelCase',
         'with.dot': 'with.dot',
-        regex: new RegExp('some-regex.*'),
-        regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+        regex: new RegExp('some-regex.*', 'gi')
       }
     },
     from_env: {
@@ -64,8 +61,7 @@ module.exports = {
         nested: 'nestedCamelCase'
       },
       'with.dot': 'WITH_DOT',
-      regex: new RegExp('some-regex-from-env.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
+      regex: new RegExp('some-regex-from-env.*', 'gi')
     },
     from_test_json: {
       number: 1000.0,
@@ -79,8 +75,7 @@ module.exports = {
       camelCase: 'test',
       null: 'null',
       'with.dot': 'from_test_json',
-      regex: 'some-regex-from-test-json.*',
-      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
+      regex: 'some-regex-from-test-json.*'
     }
   }
 };

--- a/test/scenarios/notDotEnv.js
+++ b/test/scenarios/notDotEnv.js
@@ -13,7 +13,9 @@ module.exports = {
     FROM_ENV_OBJECT_ARRAY: 'c,d,e',
     FROM_ENV_CAMEL_CASE: 'snake_case',
     FROM_ENV_NESTEDCAMELCASE_NESTED: 'nested snake case',
-    FROM_ENV_WITH_DOT: 'WITH_DOT'
+    FROM_ENV_WITH_DOT: 'WITH_DOT',
+    FROM_ENV_REGEX: 'some-regex-from-env.*',
+    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
   },
   expected: {
     nested: {
@@ -26,7 +28,9 @@ module.exports = {
       stringArray: ['a', 'b', 'c'],
       objectArray: [{}, {}],
       camelCase: 'camelCase',
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     },
     from: {
       dot_env: {
@@ -39,7 +43,9 @@ module.exports = {
         stringArray: ['a', 'b', 'c'],
         objectArray: [{}, {}],
         camelCase: 'camelCase',
-        'with.dot': 'with.dot'
+        'with.dot': 'with.dot',
+        regex: new RegExp('some-regex.*'),
+        regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
       }
     },
     from_env: {
@@ -56,7 +62,9 @@ module.exports = {
       nestedCamelCase: {
         nested: 'nested snake case'
       },
-      'with.dot': 'WITH_DOT'
+      'with.dot': 'WITH_DOT',
+      regex: new RegExp('some-regex-from-env.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
     },
     from_test_json: {
       number: 1000.0,
@@ -69,7 +77,9 @@ module.exports = {
       objectArray: ['1'],
       camelCase: 'test',
       null: 'null',
-      'with.dot': 'from_test_json'
+      'with.dot': 'from_test_json',
+      regex: 'some-regex-from-test-json.*',
+      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
     }
   }
 };

--- a/test/scenarios/notDotEnv.js
+++ b/test/scenarios/notDotEnv.js
@@ -14,8 +14,7 @@ module.exports = {
     FROM_ENV_CAMEL_CASE: 'snake_case',
     FROM_ENV_NESTEDCAMELCASE_NESTED: 'nested snake case',
     FROM_ENV_WITH_DOT: 'WITH_DOT',
-    FROM_ENV_REGEX: 'some-regex-from-env.*',
-    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
+    FROM_ENV_REGEX: 'some-regex-from-env.*'
   },
   expected: {
     nested: {
@@ -29,8 +28,7 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     },
     from: {
       dot_env: {
@@ -44,8 +42,7 @@ module.exports = {
         objectArray: [{}, {}],
         camelCase: 'camelCase',
         'with.dot': 'with.dot',
-        regex: new RegExp('some-regex.*'),
-        regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+        regex: new RegExp('some-regex.*', 'gi')
       }
     },
     from_env: {
@@ -63,8 +60,7 @@ module.exports = {
         nested: 'nested snake case'
       },
       'with.dot': 'WITH_DOT',
-      regex: new RegExp('some-regex-from-env.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
+      regex: new RegExp('some-regex-from-env.*', 'gi')
     },
     from_test_json: {
       number: 1000.0,
@@ -78,8 +74,7 @@ module.exports = {
       camelCase: 'test',
       null: 'null',
       'with.dot': 'from_test_json',
-      regex: 'some-regex-from-test-json.*',
-      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
+      regex: 'some-regex-from-test-json.*'
     }
   }
 };

--- a/test/scenarios/notTest.js
+++ b/test/scenarios/notTest.js
@@ -14,8 +14,7 @@ module.exports = {
     FROM_ENV_CAMELCASE: 'snake_case',
     FROM_ENV_NESTEDCAMELCASE_NESTED: 'nested snake case',
     FROM_ENV_WITH_DOT: 'WITH_DOT',
-    FROM_ENV_REGEX: 'some-regex-from-env.*',
-    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
+    FROM_ENV_REGEX: 'some-regex-from-env.*'
   },
   expected: {
     nested: {
@@ -30,8 +29,7 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     },
     from: {
       dot_env: {
@@ -45,8 +43,7 @@ module.exports = {
         objectArray: ['o', 'b', 'j', 'e', 'c', 't'],
         camelCase: 'snake_case',
         'with.dot': 'WITH_DOT_ENV',
-        regex: new RegExp('some-regex-from-dot-env.*'),
-        regexWithFlags: new RegExp('some-regex-with-flags-from-dot-env.*', 'gmi')
+        regex: new RegExp('some-regex-from-dot-env.*', 'gi')
       }
     },
     from_env: {
@@ -64,8 +61,7 @@ module.exports = {
         nested: 'nested snake case'
       },
       'with.dot': 'WITH_DOT',
-      regex: new RegExp('some-regex-from-env.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
+      regex: new RegExp('some-regex-from-env.*', 'gi')
     },
     from_test_json: {
       number: 0.0,
@@ -79,8 +75,7 @@ module.exports = {
       camelCase: 'camelCase',
       null: null,
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     }
   }
 };

--- a/test/scenarios/notTest.js
+++ b/test/scenarios/notTest.js
@@ -13,7 +13,9 @@ module.exports = {
     FROM_ENV_OBJECT_ARRAY: 'c,d,e',
     FROM_ENV_CAMELCASE: 'snake_case',
     FROM_ENV_NESTEDCAMELCASE_NESTED: 'nested snake case',
-    FROM_ENV_WITH_DOT: 'WITH_DOT'
+    FROM_ENV_WITH_DOT: 'WITH_DOT',
+    FROM_ENV_REGEX: 'some-regex-from-env.*',
+    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
   },
   expected: {
     nested: {
@@ -27,7 +29,9 @@ module.exports = {
       //should be treated as string array
       objectArray: [{}, {}],
       camelCase: 'camelCase',
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     },
     from: {
       dot_env: {
@@ -40,7 +44,9 @@ module.exports = {
         stringArray: ['a', 'b', 'c'],
         objectArray: ['o', 'b', 'j', 'e', 'c', 't'],
         camelCase: 'snake_case',
-        'with.dot': 'WITH_DOT_ENV'
+        'with.dot': 'WITH_DOT_ENV',
+        regex: new RegExp('some-regex-from-dot-env.*'),
+        regexWithFlags: new RegExp('some-regex-with-flags-from-dot-env.*', 'gmi')
       }
     },
     from_env: {
@@ -57,7 +63,9 @@ module.exports = {
       nestedCamelCase: {
         nested: 'nested snake case'
       },
-      'with.dot': 'WITH_DOT'
+      'with.dot': 'WITH_DOT',
+      regex: new RegExp('some-regex-from-env.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
     },
     from_test_json: {
       number: 0.0,
@@ -70,7 +78,9 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       null: null,
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     }
   }
 };

--- a/test/scenarios/replaceAll.js
+++ b/test/scenarios/replaceAll.js
@@ -15,8 +15,7 @@ module.exports = {
     FROM_ENV_CAMELCASE: 'snake_case',
     FROM_ENV_NESTED_CAMEL_CASE_NESTED: 'nested snake case',
     FROM_ENV_WITH_DOT: 'WITH_DOT',
-    FROM_ENV_REGEX: 'some-regex-from-env.*',
-    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
+    FROM_ENV_REGEX: 'some-regex-from-env.*'
   },
   expected: {
     nested: {
@@ -31,8 +30,7 @@ module.exports = {
       objectArray: [{}, {}],
       camelCase: 'camelCase',
       'with.dot': 'with.dot',
-      regex: new RegExp('some-regex.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
+      regex: new RegExp('some-regex.*', 'gi')
     },
     from: {
       dot_env: {
@@ -46,8 +44,7 @@ module.exports = {
         objectArray: ['o', 'b', 'j', 'e', 'c', 't'],
         camelCase: 'snake_case',
         'with.dot': 'WITH_DOT_ENV',
-        regex: new RegExp('some-regex-from-dot-env.*'),
-        regexWithFlags: new RegExp('some-regex-with-flags-from-dot-env.*', 'gmi')
+        regex: new RegExp('some-regex-from-dot-env.*', 'gi')
       }
     },
     from_env: {
@@ -65,8 +62,7 @@ module.exports = {
         nested: 'nested snake case'
       },
       'with.dot': 'WITH_DOT',
-      regex: new RegExp('some-regex-from-env.*'),
-      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
+      regex: new RegExp('some-regex-from-env.*', 'gi')
     },
     from_test_json: {
       number: 1000.0,
@@ -80,8 +76,7 @@ module.exports = {
       camelCase: 'test',
       null: 'null',
       'with.dot': 'from_test_json',
-      regex: 'some-regex-from-test-json.*',
-      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
+      regex: 'some-regex-from-test-json.*'
     }
   }
 };

--- a/test/scenarios/replaceAll.js
+++ b/test/scenarios/replaceAll.js
@@ -14,7 +14,9 @@ module.exports = {
     FROM_ENV_ARRAY_TWO: '',
     FROM_ENV_CAMELCASE: 'snake_case',
     FROM_ENV_NESTED_CAMEL_CASE_NESTED: 'nested snake case',
-    FROM_ENV_WITH_DOT: 'WITH_DOT'
+    FROM_ENV_WITH_DOT: 'WITH_DOT',
+    FROM_ENV_REGEX: 'some-regex-from-env.*',
+    FROM_ENV_REGEX_WITH_FLAGS: '/some-regex-with-flags-from-env.*/g'
   },
   expected: {
     nested: {
@@ -28,7 +30,9 @@ module.exports = {
       //should be treated as string array
       objectArray: [{}, {}],
       camelCase: 'camelCase',
-      'with.dot': 'with.dot'
+      'with.dot': 'with.dot',
+      regex: new RegExp('some-regex.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags.*', 'gi')
     },
     from: {
       dot_env: {
@@ -41,7 +45,9 @@ module.exports = {
         stringArray: ['a', 'b', 'c'],
         objectArray: ['o', 'b', 'j', 'e', 'c', 't'],
         camelCase: 'snake_case',
-        'with.dot': 'WITH_DOT_ENV'
+        'with.dot': 'WITH_DOT_ENV',
+        regex: new RegExp('some-regex-from-dot-env.*'),
+        regexWithFlags: new RegExp('some-regex-with-flags-from-dot-env.*', 'gmi')
       }
     },
     from_env: {
@@ -58,7 +64,9 @@ module.exports = {
       nestedCamelCase: {
         nested: 'nested snake case'
       },
-      'with.dot': 'WITH_DOT'
+      'with.dot': 'WITH_DOT',
+      regex: new RegExp('some-regex-from-env.*'),
+      regexWithFlags: new RegExp('some-regex-with-flags-from-env.*', 'g')
     },
     from_test_json: {
       number: 1000.0,
@@ -71,7 +79,9 @@ module.exports = {
       objectArray: ['1'],
       camelCase: 'test',
       null: 'null',
-      'with.dot': 'from_test_json'
+      'with.dot': 'from_test_json',
+      regex: 'some-regex-from-test-json.*',
+      regexWithFlags: '/some-regex-with-flags-from-test-json.*/i'
     }
   }
 };


### PR DESCRIPTION
Adds special handling when the value of a config key is an instance of RegExp class.

Allows the env config override to set regex flags assuming they follow the convention of: `/pattern/flags` (example `/hello world/gi`)